### PR TITLE
Add missing alter privileges statement

### DIFF
--- a/src/main/scala/uk/gov/nationalarchives/db/users/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/db/users/Lambda.scala
@@ -52,6 +52,7 @@ class Lambda {
     //Grants permissions for any new tables that are created.
     //This is not needed for the migrations user as it will be creating the tables so it will own them/
     sql"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT SELECT, INSERT, UPDATE ON TABLES TO $apiUser;".execute().apply()
+    sql"ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT ALL PRIVILEGES ON SEQUENCES TO $apiUser;".execute().apply()
   }
 
   def grantConnectAndUsage(user: SQLSyntax, database: SQLSyntax) = {


### PR DESCRIPTION
The consignment_id sequence is created after the users are created so I need to give permissions for the consignment_api_user to be able to use any new sequences that are created.
