### PR TITLE
Create Keycloak user with IAM auth.

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -6,7 +6,6 @@ consignment-api-user = "consignment_api_user"
 migrations-user = "migrations_user"
 keycloak-user = "keycloak_user"
 bastion-user = "bastion_user"
-keycloak-password = ${?KEYCLOAK_PASSWORD}
 function-name = ${AWS_LAMBDA_FUNCTION_NAME}
 kms-endpoint = "https://kms.eu-west-2.amazonaws.com"
 database-name = ${DATABASE_NAME}

--- a/src/main/scala/uk/gov/nationalarchives/db/users/Lambda.scala
+++ b/src/main/scala/uk/gov/nationalarchives/db/users/Lambda.scala
@@ -34,12 +34,7 @@ class Lambda {
 
   def createKeycloakUser: Boolean = {
     val user = createIamAuthenticationUser(lambdaConfig.keycloakUser)
-    val keycloakPassword = lambdaConfig.keycloakPassword match {
-      case Some(value) => value
-      case None => throw new RuntimeException("Keycloak password has not been provided")
-    }
-    val password = sqls.createUnsafely(keycloakPassword)
-    sql"CREATE USER $user WITH PASSWORD '$password'".execute()
+
     grantConnectAndUsage(user, sqls.createUnsafely("keycloak"))
     sql"GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO $user;".execute.apply()
     //Grant access to new tables. Keycloak upgrades sometimes create new tables


### PR DESCRIPTION
When I did the move to IAM authentication for Keycloak, I updated the
users manually as this lambda doesn't allow updating users.

Now we're going to be running this for the new single instance database
and the Keycloak user needs to have IAM auth set up.
