### PR TITLE
Use the new modular AWS utils

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,12 +12,15 @@ lazy val root = (project in file("."))
       "TDR Releases" at "s3://tdr-releases-mgmt"
     ),
     libraryDependencies ++= Seq(
-      awsUtils,
+      kmsUtils,
       pureConfig,
       postgres,
       scalikeJdbc,
       scalaTest % Test,
-      wiremock % Test
+      wiremock % Test,
+      circeCore % Test,
+      circeGeneric % Test,
+      circeParser % Test
     )
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,7 +1,12 @@
 import sbt._
 
 object Dependencies {
-  lazy val awsUtils =  "uk.gov.nationalarchives" %% "tdr-aws-utils" % "0.1.53"
+  private val circeVersion = "0.14.3"
+
+  lazy val circeCore = "io.circe" %% "circe-core" % circeVersion
+  lazy val circeGeneric = "io.circe" %% "circe-generic" % circeVersion
+  lazy val circeParser = "io.circe" %% "circe-parser" % circeVersion
+  lazy val kmsUtils =  "uk.gov.nationalarchives" %% "kms-utils" % "0.1.55"
   lazy val postgres = "org.postgresql" % "postgresql" % "42.5.0"
   lazy val scalaTest = "org.scalatest" %% "scalatest" % "3.2.14"
   lazy val scalikeJdbc = "org.scalikejdbc" %% "scalikejdbc" % "4.0.0"

--- a/src/main/scala/uk/gov/nationalarchives/db/users/Config.scala
+++ b/src/main/scala/uk/gov/nationalarchives/db/users/Config.scala
@@ -3,8 +3,8 @@ package uk.gov.nationalarchives.db.users
 import pureconfig._
 import pureconfig.generic.auto._
 import scalikejdbc.{AutoSession, ConnectionPool}
-import uk.gov.nationalarchives.aws.utils.Clients.kms
-import uk.gov.nationalarchives.aws.utils.KMSUtils
+import uk.gov.nationalarchives.aws.utils.kms.KMSClients.kms
+import uk.gov.nationalarchives.aws.utils.kms.KMSUtils
 
 object Config {
 


### PR DESCRIPTION
The AWS utils library now publishes different packages for each AWS
service. This updates the imports.

I've also included circe for the tests because it's no longer bundled
with most of the AWS utils.
